### PR TITLE
Add support for creating plugins by passing a url to the template

### DIFF
--- a/cmd/plugin/init.js
+++ b/cmd/plugin/init.js
@@ -39,8 +39,8 @@ function initPlugin(args) {
 
     console.log('\x1b[32mCreating Plugin ' + args[2] + ' with template ' + args[3] + '\x1b[0m');
 
-    var gitUrl = isURL(args[3]) || isDirectory(args[3]) 
-      ? args[3] 
+    var gitUrl = isURL(args[3]) || isDirectory(args[3])
+      ? args[3]
       : `https://github.com/BuildFire/${args[3]}PluginTemplate.git`;
     git.clone(gitUrl, targetPath)
     .then(function() {

--- a/cmd/plugin/init.js
+++ b/cmd/plugin/init.js
@@ -5,8 +5,13 @@ var isSdkDirectory = require('../../tools/isSdkDirectory');
 var rmDir = require('../../tools/rmDir');
 var fs = require('fs');
 
-function isURL(str) {
+function isUrl(str) {
   var pattern = new RegExp(/(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/)
+  return str && pattern.test(str);
+}
+
+function isGitUrl(str) {
+  var pattern = new RegExp(/(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/);
   return str && pattern.test(str);
 }
 
@@ -39,7 +44,7 @@ function initPlugin(args) {
 
     console.log('\x1b[32mCreating Plugin ' + args[2] + ' with template ' + args[3] + '\x1b[0m');
 
-    var gitUrl = isURL(args[3]) || isDirectory(args[3])
+    var gitUrl = isUrl(args[3]) || isGitUrl(args[3]) || isDirectory(args[3])
       ? args[3]
       : `https://github.com/BuildFire/${args[3]}PluginTemplate.git`;
     git.clone(gitUrl, targetPath)

--- a/cmd/plugin/init.js
+++ b/cmd/plugin/init.js
@@ -37,7 +37,7 @@ function initPlugin(args) {
       return console.log('\x1b[31mError: Plugin folder with that name already exists');
     }
 
-    console.log('\x1b[32mCreating Plugin ' + args[2] + ' with tempalte ' + args[3] + '\x1b[0m');
+    console.log('\x1b[32mCreating Plugin ' + args[2] + ' with template ' + args[3] + '\x1b[0m');
 
     var gitUrl = isURL(args[3]) || isDirectory(args[3]) 
       ? args[3] 

--- a/cmd/plugin/init.js
+++ b/cmd/plugin/init.js
@@ -16,8 +16,12 @@ function isGitUrl(str) {
 }
 
 function isDirectory(str) {
-  var stats = fs.statSync(str);
-  return stats.isDirectory();
+  try {
+    var stats = fs.statSync(str);
+    return stats.isDirectory();
+  } catch(e) {
+    return false;
+  }
 }
 
 function initPlugin(args) {

--- a/cmd/plugin/init.js
+++ b/cmd/plugin/init.js
@@ -3,7 +3,17 @@ var git = require('simple-git/promise')();
 var folderExists = require('../../tools/folderExists');
 var isSdkDirectory = require('../../tools/isSdkDirectory');
 var rmDir = require('../../tools/rmDir');
+var fs = require('fs');
 
+function isURL(str) {
+  var pattern = new RegExp(/(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/)
+  return str && pattern.test(str);
+}
+
+function isDirectory(str) {
+  var stats = fs.statSync(str);
+  return stats.isDirectory();
+}
 
 function initPlugin(args) {
     var cwd = process.cwd();
@@ -29,7 +39,10 @@ function initPlugin(args) {
 
     console.log('\x1b[32mCreating Plugin ' + args[2] + ' with tempalte ' + args[3] + '\x1b[0m');
 
-    git.clone('https://github.com/BuildFire/' + args[3] + 'PluginTemplate.git', targetPath)
+    var gitUrl = isURL(args[3]) || isDirectory(args[3]) 
+      ? args[3] 
+      : `https://github.com/BuildFire/${args[3]}PluginTemplate.git`;
+    git.clone(gitUrl, targetPath)
     .then(function() {
       rmDir(path.join(targetPath, '.git'));
 


### PR DESCRIPTION
This adds support to the CLI for creating plugins from templates passed as 
- http/https urls
- git urls
- local directories

This will be helpful for plugin developers as they create their own plugin templates. 

Example usage: 
```
buildfire plugin init new-plugin https://github.com/jtberglund/my-custom-plugin
```
```
buildfire plugin init new-plugin git@github.com:jtberglund/my-custom-plugin
```
```
buildfire plugin init new-plugin ~/dev/my-custom-plugin
```